### PR TITLE
Fix URL endpoints for WA membership, and check for WA resignation status properly

### DIFF
--- a/src/networking/html/handlers/worldAssembly.ts
+++ b/src/networking/html/handlers/worldAssembly.ts
@@ -24,7 +24,7 @@ export async function handleApply(
 		};
 	}
 
-	const text = await context.getNsHtmlPage("page=UN_Status", payload);
+	const text = await context.getNsHtmlPage("page=UN_status", payload);
 	if (
 		text.includes(
 			"Your application to join the World Assembly has been received!",
@@ -49,7 +49,7 @@ export async function handleJoin(
 	nationName: string,
 	appId: string,
 ): Promise<boolean> {
-	const text = await context.getNsHtmlPage("cgi-bin/", {
+	const text = await context.getNsHtmlPage("cgi-bin/join_un.cgi", {
 		nation: nationName,
 		appid: appId.trim(),
 	});
@@ -68,7 +68,7 @@ export async function handleJoin(
  * @returns A Promise that resolves to true if the resignation is successful, false otherwise.
  */
 export async function handleResign(context: NSScript): Promise<boolean> {
-	const text = await context.getNsHtmlPage("page=UN_Status", {
+	const text = await context.getNsHtmlPage("page=UN_status", {
 		action: "leave_UN",
 		submit: "1",
 	});

--- a/src/networking/html/handlers/worldAssembly.ts
+++ b/src/networking/html/handlers/worldAssembly.ts
@@ -73,7 +73,7 @@ export async function handleResign(context: NSScript): Promise<boolean> {
 		submit: "1",
 	});
 	if (
-		text.includes("From context moment forward, your nation is on its own.")
+		text.includes("From this moment forward, your nation is on its own.")
 	) {
 		context.statusBubble.success("Resigned from World Assembly");
 		return true;


### PR DESCRIPTION
WA join endpoint was "/cgi-bin" for some reason, corrected to "/cgi-bin/join_un.cgi"

WA apply and resign endpoints changed from "/page=UN_Status" to "/page=UN_status". Not sure if those are case-sensitive or not but the latter is the one used by NS and I can confirm it works with the latter, not tested with the former

WA join was checking for the string "From context moment forward, your nation is on its own." instead of "From this moment forward, your nation is on its own." so it was always "failing" even if the request went through properly - fixed.