### PR TITLE
Add methods to appoint/dismiss ROs and edit Delegate/Governor offices

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -342,6 +342,67 @@ export class NSScript {
 	}
 
 	/**
+	 * Attempts to edit or appoint a regional officer in a region (given that the current nation has Executive authority there).
+	 * @param nationName The nation to give said office to.
+	 * @param officeName The office name to use.
+	 * @param authority Authority to give to the officer: 
+	 * "A" for Appearance, "B" for Border Control, "C" for Communications, "E" for Embassies, "P" for Polls and "S" for Successor.
+	 * Example: "ACEP" will set the office's authority to Appearance, Communications, Embassies and Polls.
+	 * @param regionName The name of the region to edit/create the office in. If not given, defaults to the current region.
+	 * @returns A Promise that resolves to true if the operation is successful, false otherwise.
+	 */
+	public async editRegionalOfficer(
+		nationName: string,
+		officeName: string,
+		authority: string,
+		regionName?: string,
+	): Promise<boolean> {
+		return region.handleEditRO(this, nationName, officeName, authority, regionName);
+	}
+
+	/**
+	 * Attempts to dismiss a regional officer in a region (given that the current nation has Executive authority there).
+	 * @param nationName The officer to dismiss.
+	 * @param regionName The name of the region to dismiss the office in. If not given, defaults to the current region.
+	 * @returns A Promise that resolves to true if the operation is successful, false otherwise.
+	 */
+	public async dismissRegionalOfficer(
+		nationName: string,
+		regionName?: string,
+	): Promise<boolean> {
+		return region.handleDismissRO(this, nationName, regionName);
+	}
+
+	/**
+	 * Attempts to edit the delegate's authority in a region (given that the current nation has Executive authority there).
+	 * @param authority Authority to give to the delegate: 
+	 * "A" for Appearance, "B" for Border Control, "C" for Communications, "E" for Embassies, "P" for Polls and "X" for Executive.
+	 * Example: "ACEP" will set the office's authority to Appearance, Communications, Embassies and Polls.
+	 * World Assembly authority is always set and cannot be turned off.
+	 * @param regionName The name of the region to edit the delegacy of. If not given, defaults to the current region.
+	 * @returns A Promise that resolves to true if the operation is successful, false otherwise.
+	 */
+	public async editDelegate(
+		authority: string,
+		regionName?: string,
+	): Promise<boolean> {
+		return region.handleEditDelegate(this, authority, regionName);
+	}
+
+	/**
+	 * Attempts to edit the governor's title in a region (given that the current nation has Executive authority there).
+	 * @param officeName The title to give the Governor.
+	 * @param regionName The name of the region to edit the Governorship of. If not given, defaults to the current region.
+	 * @returns A Promise that resolves to true if the operation is successful, false otherwise.
+	 */
+	public async renameGovernor(
+		officeName: string,
+		regionName?: string,
+	): Promise<boolean> {
+		return region.handleRenameGovernor(this, officeName, regionName);
+	}
+
+	/**
 	 * Attempts to apply to or reapply to the World Assembly.
 	 * @param reapply Whether to reapply to the World Assembly if you've already recently applied
 	 * @returns A Promise that resolves to true if the application is successful, false otherwise.

--- a/src/networking/html/handlers/region.ts
+++ b/src/networking/html/handlers/region.ts
@@ -213,4 +213,138 @@ export async function handleTag(
 	);
 	return false;
 }
-// TODO: add adding tags to regions, as well as uploading flags/banners, as well as detag wfe's from pauls website
+
+export async function handleEditRO(
+	context: NSScript,
+	nationName: string,
+	officeName: string,
+	authority: string,
+	regionName?: string,
+): Promise<boolean> {
+	const payload: Record<string, string> = {
+		nation: nationName,
+		office_name: officeName,
+		editofficer: "1",
+	};
+
+	if(authority.includes("A")) payload.authority_A = "on";
+	if(authority.includes("B")) payload.authority_B = "on";
+	if(authority.includes("C")) payload.authority_C = "on";
+	if(authority.includes("E")) payload.authority_E = "on";
+	if(authority.includes("P")) payload.authority_P = "on";
+	if(authority.includes("S")) payload.authority_S = "on";
+
+	let page = "page=region_control";
+	if(regionName) {
+		page += `/region=${regionName}`;
+		payload.region = regionName;
+	}
+
+	const text = await context.getNsHtmlPage(page, payload);
+	if(text.includes("Appointed") && text.includes("with authority over")) {
+		context.statusBubble.success(`Appointed ${prettify(nationName)} as RO`);
+		return true;
+	}
+	if (text.includes("Renamed the authority held by") 
+		|| ((text.includes("authority from") || text.includes("authority to")) 
+		&& (text.includes("Removed") || text.includes("Granted")))) {
+		context.statusBubble.success(`Edited ${prettify(nationName)}'s office`);
+		return true;
+	}
+	context.statusBubble.warn(
+		`Failed to appoint/edit ${prettify(nationName)} as RO`,
+	);
+	return false;
+}
+
+export async function handleDismissRO(
+	context: NSScript,
+	nationName: string,
+	regionName?: string,
+): Promise<boolean> {
+	const payload: Record<string, string> = {
+		nation: nationName,
+		abolishofficer: "1",
+	};
+
+	let page = "page=region_control";
+	if(regionName) {
+		page += `/region=${regionName}`;
+		payload.region = regionName;
+	}
+
+	const text = await context.getNsHtmlPage(page, payload);
+	if(text.includes("Dismissed") && text.includes("as")) {
+		context.statusBubble.success(`Dismissed ${prettify(nationName)} from office`);
+		return true;
+	}
+	context.statusBubble.warn(
+		`Failed to dismiss ${prettify(nationName)} from office`,
+	);
+	return false;
+}
+
+export async function handleEditDelegate(
+	context: NSScript,
+	authority: string,
+	regionName?: string,
+): Promise<boolean> {
+	const payload: Record<string, string> = {
+		office: "delegate",
+		editofficer: "1",
+		authority_W: "on", // world assembly authority always on
+	};
+
+	if(authority.includes("A")) payload.authority_A = "on";
+	if(authority.includes("B")) payload.authority_B = "on";
+	if(authority.includes("C")) payload.authority_C = "on";
+	if(authority.includes("E")) payload.authority_E = "on";
+	if(authority.includes("P")) payload.authority_P = "on";
+	if(authority.includes("X")) payload.authority_X = "on";
+
+	let page = "page=region_control";
+	if(regionName) {
+		page += `/region=${regionName}`;
+		payload.region = regionName;
+	}
+
+	const text = await context.getNsHtmlPage(page, payload);
+	if (text.includes("Set Delegate authority to:")) {
+		context.statusBubble.success("Modified delegate authority");
+		return true;
+	}
+	context.statusBubble.warn(
+		"Failed to modify delegate authority",
+	);
+	return false;
+}
+
+export async function handleRenameGovernor(
+	context: NSScript,
+	officeName: string,
+	regionName?: string,
+): Promise<boolean> {
+	const payload: Record<string, string> = {
+		office: "governor",
+		office_name: officeName,
+		editofficer: "1",
+	};
+
+	let page = "page=region_control";
+	if(regionName) {
+		page += `/region=${regionName}`;
+		payload.region = regionName;
+	}
+
+	const text = await context.getNsHtmlPage(page, payload);
+	if (text.includes("Renamed the Governor's office")) {
+		context.statusBubble.success("Renamed Governor");
+		return true;
+	}
+	context.statusBubble.warn(
+		"Failed to rename Governor",
+	);
+	return false;
+}
+
+// TODO: uploading flags/banners, as well as detag wfe's from pauls website


### PR DESCRIPTION
Title says it all

Seemingly, providing a region is not required, and NS will just use whatever region you're in, even though the site itself always passes the current region in the form data.